### PR TITLE
Fix parameter order of `format!` macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl TmpDir {
                 .collect()
         };
 
-        inner.push(&format!("{}-{}", s, prefix.as_ref()));
+        inner.push(&format!("{}-{}", prefix.as_ref(), s));
 
         fs::create_dir(&inner).await?;
         Ok(Self { inner })


### PR DESCRIPTION
Keep consistency with doc.

Closes #2.